### PR TITLE
send crlf after chunk

### DIFF
--- a/lib/reel/connection.rb
+++ b/lib/reel/connection.rb
@@ -139,6 +139,7 @@ module Reel
       chunk_header = chunk.bytesize.to_s(16) + Response::CRLF
       @socket << chunk_header
       @socket << chunk
+      @socket << Response::CRLF
     end
     alias_method :<<, :write
 

--- a/spec/reel/connection_spec.rb
+++ b/spec/reel/connection_spec.rb
@@ -77,7 +77,7 @@ describe Reel::Connection do
       end
 
       crlf = "\r\n"
-      fixture = "5#{crlf}Hello5#{crlf}World0#{crlf*2}"
+      fixture = "5#{crlf}Hello#{crlf}5#{crlf}World#{crlf}0#{crlf*2}"
       response[(response.length - fixture.length)..-1].should eq fixture
     end
   end


### PR DESCRIPTION
According to wikipedia:

Each chunk starts with the number of octets of the data it embeds expressed in hexadecimal followed by optional parameters (chunk extension) and a terminating CRLF sequence, followed by the chunk data. The chunk is terminated by CRLF.

This adds the terminating CRLF to the chunk.
