### PR TITLE
Server#finalize fails if the socket was unable to be created

### DIFF
--- a/lib/reel/app.rb
+++ b/lib/reel/app.rb
@@ -27,7 +27,7 @@ module Reel
     end
 
     def terminate
-      @server.terminate
+      @server.terminate if @server
     end
   end
 end

--- a/lib/reel/server.rb
+++ b/lib/reel/server.rb
@@ -17,7 +17,7 @@ module Reel
     end
 
     def finalize
-      @server.close
+      @server.close if @server
     end
 
     def run

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@ def with_reel(handler)
   server = Reel::Server.new(example_addr, example_port, &handler)
   yield server
 ensure
-  server.terminate
+  server.terminate if server
 end
 
 def with_socket_pair


### PR DESCRIPTION
We should only `close` if possible. 

```
Errno::EACCES: Permission denied - bind(2)
    /Users/tim/Projects/celluloid-io/lib/celluloid/io/tcp_server.rb:11:in `initialize'
    /Users/tim/Projects/celluloid-io/lib/celluloid/io/tcp_server.rb:11:in `new'
    /Users/tim/Projects/celluloid-io/lib/celluloid/io/tcp_server.rb:11:in `initialize'
    /Users/tim/Projects/reel/lib/reel/server.rb:13:in `new'
    /Users/tim/Projects/reel/lib/reel/server.rb:13:in `initialize'

NoMethodError: undefined method `close' for nil:NilClass
    /Users/tim/Projects/reel/lib/reel/server.rb:20:in `finalize'
    /Users/tim/Projects/celluloid/lib/celluloid/actor.rb:386:in `block in run_finalizer'
    /Users/tim/Projects/celluloid/lib/celluloid/tasks/task_fiber.rb:28:in `block in initialize'
```
