### PR TITLE
Hanging on celluloid master

### DIFF
--- a/lib/reel/server.rb
+++ b/lib/reel/server.rb
@@ -16,6 +16,8 @@ module Reel
       async.run
     end
 
+    execute_block_on_receiver :initialize
+
     def finalize
       @server.close if @server
     end


### PR DESCRIPTION
With the changes to the block execution, there are some problems. 
I found that the `initialize` blocks are not actually executing on the receiver even though they were declared to run this way. 

With that changed, there are still hangs in `Reel::App` spec. 
