### PR TITLE
specify the number of workers using the rackup command, fixes #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ by Celluloid. In addition, the Rack specification mandates that request bodies
 are rewindable, which prevents streaming request bodies as the spec dictates
 they must be written to disk.
 
+To run `.ru` file using Reel w/ 16 workers
+
+```
+rackup -p 1234 -s reel config.ru -Enone -O "workers=16" 
+```
+
 To really leverage Reel's capabilities, you must use Reel via its own API,
 or another Ruby library with direct Reel support.
 

--- a/examples/websocket_rack.sh
+++ b/examples/websocket_rack.sh
@@ -1,1 +1,1 @@
-rackup -s reel websocket.ru -Enone
+rackup -s reel websocket.ru -Enone -O "workers=16"

--- a/lib/rack/handler/reel.rb
+++ b/lib/rack/handler/reel.rb
@@ -83,6 +83,7 @@ module Rack
         options = options.inject({}) { |h, (k,v)| h[k.downcase] = v ; h }
         options[:rackup] = options[:config] if options[:config]
         options[:port] = options[:port].to_i if options[:port]
+        options[:workers] = options[:workers].to_i if options[:workers]
         options
       end
     end


### PR DESCRIPTION
ability to specify the number of workers using rackup generic options API, e.g -O workers=16
