### PR TITLE
Copy ping payload data when creating a pong response

### DIFF
--- a/lib/reel/websocket.rb
+++ b/lib/reel/websocket.rb
@@ -36,8 +36,8 @@ module Reel
         close
       end
 
-      @parser.on_ping do
-        @socket << ::WebSocket::Message.pong.to_data
+      @parser.on_ping do |payload|
+        @socket << ::WebSocket::Message.pong(payload).to_data
       end
     end
 

--- a/reel.gemspec
+++ b/reel.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'celluloid-io',     '>= 0.8.0'
   gem.add_runtime_dependency 'http',             '>= 0.2.0'
   gem.add_runtime_dependency 'http_parser.rb',   '>= 0.5.3'
-  gem.add_runtime_dependency 'websocket_parser', '>= 0.1.2'
+  gem.add_runtime_dependency 'websocket_parser', '>= 0.1.4'
   gem.add_runtime_dependency 'rack',             '>= 1.4.0'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
According to the RFC6455 spec section 5.5.3:

> A Pong frame sent in response to a Ping frame must have identical
> "Application data" as found in the message body of the Ping frame
> being replied to.

I've updated websocket_parser to allow ping and pong messages with arbitrary payloads and to provide the payload as a parameter to the on_ping and on_pong callbacks.

This PR updates Reel to use this feature in the latest version of websocket_parser. 
