### PR TITLE
fix TimeClient crash on page refresh

### DIFF
--- a/examples/websockets.rb
+++ b/examples/websockets.rb
@@ -32,6 +32,9 @@ class TimeClient
 
   def notify_time_change(topic, new_time)
     @socket << new_time.inspect
+  rescue Errno::EPIPE
+    info "Socket no longer writable (client disconnected)"
+    terminate
   rescue Reel::SocketError
     info "Time client disconnected"
     terminate


### PR DESCRIPTION
When a client refreshes the page, the websocket is reconnected and the
old one becomes stale. The next time notification causes the server to
write to an invalid pipe, resulting in Errno::EPIPE. That exception is
caught now, letting the client terminate gently.
