### PR TITLE
Disable Nagle's alrogithm by default.

### DIFF
--- a/lib/reel/server.rb
+++ b/lib/reel/server.rb
@@ -11,6 +11,7 @@ module Reel
     def initialize(host, port, backlog = DEFAULT_BACKLOG, &callback)
       # This is actually an evented Celluloid::IO::TCPServer
       @server = TCPServer.new(host, port)
+      @server.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       @server.listen(backlog)
       @callback = callback
       async.run


### PR DESCRIPTION
For a webserver where requests/responses are usually large enough to be contained in a packet, the Nagle's algorithm slows the last packet sent.

This configuration is probably used in most ruby web servers. I only checked for Puma though.
