### PR TITLE
Added a new benchmark using a Connection Pool

### DIFF
--- a/benchmarks/reel_pool.rb
+++ b/benchmarks/reel_pool.rb
@@ -1,0 +1,27 @@
+require 'bundler/setup'
+require 'reel'
+
+class MyConnectionHandler
+  include Celluloid
+
+  def handle_connection(connection)
+    connection.each_request { |req| handle_request(req) }
+  rescue Reel::SocketError
+    connection.close
+  end
+
+  def handle_request(request)
+    request.respond :ok, ''
+  end
+end
+
+connectionPool = MyConnectionHandler.pool
+
+Reel::Server.run('127.0.0.1', 3000) do |connection|
+  # We're handing this connection off to another actor, so
+  # we detach it first before handing it off
+  connection.detach
+
+  # Let a Connection Pool handle the connections for Roflscale Applications
+  connectionPool.async.handle_connection(connection)
+end


### PR DESCRIPTION
On a Core2 Quad Q9550 (Six years old) running Debian 7 inside VMware on Windows Server 2008 i got 12k requests/s with rubinius-head

```
$ wrk http://localhost:3000
Running 10s test @ http://localhost:3000
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   811.95us    4.07ms  38.15ms   98.48%
    Req/Sec    12.04k     2.82k   14.89k    89.94%
  112474 requests in 10.01s, 7.94MB read
  Socket errors: connect 0, read 0, write 0, timeout 28
Requests/sec:  11234.99
Transfer/sec:    811.91KB
```
