### PR TITLE
Switched to websocket/driver and improved websocket handling

### DIFF
--- a/examples/websockets_new.rb
+++ b/examples/websockets_new.rb
@@ -1,0 +1,42 @@
+require 'reel'
+
+class Server < Reel::Server
+  include Celluloid::Logger
+
+  def initialize(host = '0.0.0.0', port = (ENV['PORT'] || 5000).to_i)
+    super(host, port, &method(:on_connection))
+  end
+
+  def on_connection(connection)
+    connection.each_request do |request|
+      if request.websocket?
+        handle_websocket_request(request, connection)
+      else
+        handle_http_request(request, connection)
+      end
+    end
+  end
+
+  def handle_http_request(request, connection)
+    request.respond :ok, "Hello Lame"
+  end
+
+  def handle_websocket_request(request, connection)
+    debug("[handle_websocket_request] method: #{request.method}, url: #{request.url}, uri: #{request.uri}, query_string: #{request.query_string}, fragment: #{request.fragment}, headers: #{request.headers}")
+    request.websocket.on :open do |event|
+      debug('[ws] open')
+    end
+    request.websocket.on :message do |event|
+      debug('[ws] message')
+    end
+    request.websocket.on :close do |event|
+      debug('[ws] close')
+    end
+    request.websocket.on :error do |event|
+      debug('[ws] error')
+    end
+    request.websocket.run
+    debug("[handle_websocket_request] finished")
+  end
+
+end

--- a/lib/reel/request.rb
+++ b/lib/reel/request.rb
@@ -105,8 +105,8 @@ module Reel
     # the underlying connection
     def websocket
       @websocket ||= begin
-        raise StateError, "can't upgrade this request to a websocket" unless websocket?
-        WebSocket.new(@request_info, @connection.hijack_socket)
+        raise StateError, "can't upgrade this request to a websocket" unless websocket?  
+        WebSocket.new(self, @connection)
       end
     end
 

--- a/reel.gemspec
+++ b/reel.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'celluloid-io',     '>= 0.15.0'
   gem.add_runtime_dependency 'http',             '>= 0.5.0'
   gem.add_runtime_dependency 'http_parser.rb',   '>= 0.6.0.beta.2'
-  gem.add_runtime_dependency 'websocket_parser', '>= 0.1.4'
+  gem.add_runtime_dependency 'websocket-driver', '>= 0.3.0'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
This pull request should be considered a WIP, I just wanted to open it for some feedback and sharing.

In general I found WebSocket support in Reel to be a tad flaky and hard to get working since there are not many good examples of keeping a long running persistent WebSocket open in Reel.

This pull request does the following:

* Complete re-write of the websocket handler
* Uses websocket/driver instead of websocket_parser
* Detaches the connection instead of just hijacking the socket
* Easy support for long running persistent connection
 
What I would still like to achieve with websocket support in reel:

* Automatic pinging of client from server if connection is idle for 30s or more
* A way to signal and interrupt the websocket outside of client disconnect/closing
* Specs ( I'm horrible at writing specs )
* Examples ( Lots of examples on how to use this properly and easily! )