### PR TITLE
Socket closed unexpectedly for chunked response with "Connection: close" request

### DIFF
--- a/lib/reel/connection.rb
+++ b/lib/reel/connection.rb
@@ -157,5 +157,14 @@ module Reel
       @current_request = nil
       @parser.reset
     end
+    private :reset_request
+
+    # Set response state for the connection.
+    def response_state=(state)
+      if state == :header
+        reset_request
+      end
+      @response_state = state
+    end
   end
 end

--- a/lib/reel/request.rb
+++ b/lib/reel/request.rb
@@ -100,7 +100,6 @@ module Reel
     def finish_response
       raise StateError, "not in body state" if @connection.response_state != :chunked_body
       @response_writer.finish_response
-      @connection.reset_request
       @connection.response_state = :header
     end
 


### PR DESCRIPTION
`Reel::Connection#respond` has not handled the response state correctly so that the socket was closed right after sending response headers when the request has `Connection: close` header.  It works perfectly for keep-alive request though.

```
request = Reel::Connection.new(socket).request 
request.respond :ok, :transfer_encoding => :chunked

 #  "Reel::SocketError: closed stream" raised here.
 request << "Hello" 
 request << "World"
 request.finish_response
```
