### PR TITLE
Added a way to close IO Objects encoded as a Enumerable

### DIFF
--- a/lib/reel/response/writer.rb
+++ b/lib/reel/response/writer.rb
@@ -33,8 +33,6 @@ module Reel
           Celluloid::IO.copy_stream(response.body, @socket)
         when Enumerable
           response.body.each { |chunk| write(chunk) }
-          # Webmachine-Ruby Encodes IO Objects as a Enumerable, so it needs to be closed here.
-          response.body.close if response.body.respond_to?(:close)
           finish_response
         when NilClass
           # Used for streaming Transfer-Encoding chunked responses
@@ -42,6 +40,7 @@ module Reel
         else
           raise TypeError, "don't know how to render a #{response.body.class}"
         end
+        response.body.close if response.body.respond_to?(:close)
       end
 
       # Convert headers into a string


### PR DESCRIPTION
Webmachine-Ruby Encodes IO Objects as a Enumerable. (https://github.com/seancribbs/webmachine-ruby/blob/master/lib/webmachine/decision/helpers.rb#L27 and https://github.com/seancribbs/webmachine-ruby/blob/master/lib/webmachine/streaming/io_encoder.rb#L9)
This depends on https://github.com/seancribbs/webmachine-ruby/issues/145
Another possible way to handle it would be

``` ruby
      # Render a given response object to the network socket
      def handle_response(response)
        @socket << render_header(response)
        return response.render(@socket) if response.respond_to?(:render)

        if response.body.respond_to?(:copy_stream)
          response.body.copy_stream(@socket)
        else
          case response.body
          when String
            @socket << response.body
          when IO
            Celluloid::IO.copy_stream(response.body, @socket)
          when Enumerable
            response.body.each { |chunk| write(chunk) }
            # Webmachine-Ruby Encodes IO Objects as a Enumerable, so it needs to be closed here.
            response.body.close if response.body.respond_to?(:close)
            finish_response
          when NilClass
            # Used for streaming Transfer-Encoding chunked responses
            return
          else
            raise TypeError, "don't know how to render a #{response.body.class}"
          end
        end
      end
```

But Celluloid::IO doesn't do anything then.
