### PR TITLE
Rename Reel::Server::SSL -> Reel::Server::HTTPS

### DIFF
--- a/examples/https_hello_world.rb
+++ b/examples/https_hello_world.rb
@@ -12,7 +12,7 @@ options = {
 }
 
 puts "*** Starting server on #{addr}:#{port}"
-Reel::Server::SSL.supervise(addr, port, options) do |connection|
+Reel::Server::HTTPS.supervise(addr, port, options) do |connection|
   # For keep-alive support
   connection.each_request do |request|
     # Ordinarily we'd route the request here, e.g.

--- a/lib/reel.rb
+++ b/lib/reel.rb
@@ -13,7 +13,7 @@ require 'reel/response'
 
 require 'reel/server'
 require 'reel/server/http'
-require 'reel/server/ssl'
+require 'reel/server/https'
 
 require 'reel/websocket'
 require 'reel/stream'

--- a/lib/reel/server/https.rb
+++ b/lib/reel/server/https.rb
@@ -1,14 +1,14 @@
 module Reel
   class Server
-    class SSL < Server
+    class HTTPS < Server
 
       # Create a new Reel HTTPS server
       #
       # @param [String] host address to bind to
       # @param [Fixnum] port to bind to
       # @option options [Fixnum] backlog of requests to accept
-      # @option options [String] :cert the server's SSL certificate
-      # @option options [String] :key  the server's SSL key
+      # @option options [String] :cert the server's TLS certificate
+      # @option options [String] :key  the server's TLS key
       #
       # @return [Reel::Server::SSL] Reel HTTPS server actor
       def initialize(host, port, options={}, &callback)

--- a/spec/reel/https_server_spec.rb
+++ b/spec/reel/https_server_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 require 'net/http'
 
-describe Reel::Server::SSL do
-  let(:example_ssl_port) { example_port + 1 }
-  let(:example_url)      { "https://#{example_addr}:#{example_ssl_port}#{example_path}" }
+describe Reel::Server::HTTPS do
+  let(:example_https_port) { example_port + 1 }
+  let(:example_url)      { "https://#{example_addr}:#{example_https_port}#{example_path}" }
   let(:endpoint)         { URI(example_url) }
   let(:response_body)    { "ohai thar" }
 
@@ -30,7 +30,7 @@ describe Reel::Server::SSL do
       end
     end
 
-    with_reel_sslserver(handler) do
+    with_reel_https_server(handler) do
       http         = Net::HTTP.new(endpoint.host, endpoint.port)
       http.use_ssl = true
       http.ca_file = self.ca_file
@@ -59,7 +59,7 @@ describe Reel::Server::SSL do
       end
     end
 
-    with_reel_sslserver(handler, :ca_file => self.ca_file) do
+    with_reel_https_server(handler, :ca_file => self.ca_file) do
       http         = Net::HTTP.new(endpoint.host, endpoint.port)
       http.use_ssl = true
       http.ca_file = self.ca_file
@@ -90,7 +90,7 @@ describe Reel::Server::SSL do
       end
     end
 
-    with_reel_sslserver(handler, :ca_file => self.ca_file) do
+    with_reel_https_server(handler, :ca_file => self.ca_file) do
       http         = Net::HTTP.new(endpoint.host, endpoint.port)
       http.use_ssl = true
       http.ca_file = self.ca_file
@@ -105,13 +105,13 @@ describe Reel::Server::SSL do
     raise ex if ex
   end
 
-  def with_reel_sslserver(handler, options = {})
+  def with_reel_https_server(handler, options = {})
     options = {
       :cert => server_cert,
       :key  => server_key
     }.merge(options)
 
-    server = Reel::Server::SSL.new(example_addr, example_ssl_port, options, &handler)
+    server = described_class.new(example_addr, example_https_port, options, &handler)
     yield server
   ensure
     server.terminate if server && server.alive?


### PR DESCRIPTION
I think this name makes more sense, especially since in most cases Reel is actually talking TLS instead of SSL.
