### PR TITLE
Use new version of websocket_parser and master from the http gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'celluloid',    github: 'celluloid/celluloid'
 gem 'celluloid-io', github: 'celluloid/celluloid-io'
+gem 'http',         github: 'tarcieri/http'
 
 gem 'jruby-openssl' if defined? JRUBY_VERSION
 gem 'coveralls', require: false

--- a/reel.gemspec
+++ b/reel.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'celluloid',        '>= 0.15.1'
   gem.add_runtime_dependency 'celluloid-io',     '>= 0.15.0'
-  gem.add_runtime_dependency 'http',             '~> 0.5.0'
+  gem.add_runtime_dependency 'http',             '>= 0.5.0'
   gem.add_runtime_dependency 'http_parser.rb',   '>= 0.6.0'
-  gem.add_runtime_dependency 'websocket_parser', '>= 0.1.5'
+  gem.add_runtime_dependency 'websocket_parser', '>= 0.1.6'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
Version 0.1.6 of websocket_parser is compatible with the HTTP gem master. Upgrading the dependency makes reel compatible again with the HTTP gem master.
