### PR TITLE
Update Subclass Form in README to pass Reel::Websocket instead of Reel::Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ class MyServer < Reel::Server::HTTP
   def on_connection(connection)
     connection.each_request do |request|
       if request.websocket?
-        handle_websocket(request)
+        handle_websocket(request.websocket)
       else
         handle_request(request)
       end


### PR DESCRIPTION
I'm trying celluloid/reel for the first time and was trying to get things set up given the examples. However I was getting errors using the example in the Subclass Form when calling:

```
sock << "Hello everyone out there in WebSocket land!"
```

I realized this is due to attempting to call `write` on a `Reel::Request` as opposed to a `Reel::Websocket`. It could very well be that I'm not doing things properly, but this adjustment seems to have done the trick for me.
