### PR TITLE
change non-existent HTTP::Headers.from_hash to HTTP::Headers.coerce

### DIFF
--- a/lib/reel/response.rb
+++ b/lib/reel/response.rb
@@ -36,7 +36,7 @@ module Reel
       else raise TypeError, "can't render #{@body.class} as a response body"
       end
 
-      @headers = HTTP::Headers.from_hash(headers)
+      @headers = HTTP::Headers.coerce(headers)
       @version = http_version
     end
 

--- a/lib/reel/stream.rb
+++ b/lib/reel/stream.rb
@@ -102,7 +102,7 @@ module Reel
         raise TypeError, "can't render #{@body.class} as a response body"
       end
 
-      @headers = HTTP::Headers.from_hash(headers)
+      @headers = HTTP::Headers.coerce(headers)
       @version = http_version
     end
 


### PR DESCRIPTION
Reel doesn't crash for every non-websocket request with it applied, and tests are green.
