### PR TITLE
Updated http gem version since reel is incompatible with 0.5.x series.

### DIFF
--- a/reel.gemspec
+++ b/reel.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'celluloid',        '>= 0.15.1'
   gem.add_runtime_dependency 'celluloid-io',     '>= 0.15.0'
-  gem.add_runtime_dependency 'http',             '>= 0.5.0'
+  gem.add_runtime_dependency 'http',             '>= 0.6.0.pre'
   gem.add_runtime_dependency 'http_parser.rb',   '>= 0.6.0'
   gem.add_runtime_dependency 'websocket_parser', '>= 0.1.6'
 


### PR DESCRIPTION
This change had to come with #138.
