### PR TITLE
Fix stack level too deep when writing to ChunkStream

### DIFF
--- a/lib/reel/stream.rb
+++ b/lib/reel/stream.rb
@@ -64,8 +64,8 @@ module Reel
   class ChunkStream < Stream
     def write(chunk)
       chunk_header = chunk.bytesize.to_s(16)
-      write chunk_header + Response::Writer::CRLF
-      write chunk + Response::Writer::CRLF
+      super chunk_header + Response::Writer::CRLF
+      super chunk + Response::Writer::CRLF
       self
     end
     alias :<< :write


### PR DESCRIPTION
writing to a ChunkStream throws error "stack level to deep"

this commit fixes the issue
