### PR TITLE
fix for #150

### DIFF
--- a/lib/reel/connection.rb
+++ b/lib/reel/connection.rb
@@ -124,6 +124,8 @@ module Reel
       # The client disconnected early, or there is no request
       @keepalive = false
       @request_fsm.transition :closed
+      @parser.reset
+      @current_request = nil
     end
 
     # Close the connection


### PR DESCRIPTION
This seems to fix #150 (and maybe #122 too). If the connection is lost during the response handling, the exception handler left the connection object in an inconsistent state. The next iteration of the request loop would then fail with the StateError.