### PR TITLE
Delegate #addr, #peeraddr, etc. methods in Spy.

### DIFF
--- a/lib/reel/spy.rb
+++ b/lib/reel/spy.rb
@@ -6,6 +6,7 @@ module Reel
     extend Forwardable
 
     def_delegators :@socket, :closed?
+    def_delegators :@socket, :addr, :peeraddr, :setsockopt, :getsockname
 
     def initialize(socket, logger = STDOUT)
       @socket, @logger = socket, logger


### PR DESCRIPTION
So that HTTP Common Log Format can be written regardless of whether spying is on or not.

Literally copied the line from
https://github.com/celluloid/celluloid-io/blob/master/lib/celluloid/io/tcp_socket.rb
as of c7bd7a00a9ad0842f672efc3734f75918d487410.