### PR TITLE
Unix server goes into 0.6.0 ( but not for jRuby )

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 0.6.0
-----
+-----
 * Fix stack level too deep when writing to ChunkStream
 * Use HTTP::Resonse::Status::REASONS table ( HTTP::Response::* deprecated in the HTTP gem )
 * Use Timers 3.0.0 API
@@ -14,9 +14,12 @@
 * Refactored Server::HTTPS to be more idomatic
 * Fixed jRuby related test failures
 * Fixed "ArgumentError: Data object has already been freed" caused by underlying parser.
+* FINALLY! Support for UNIX Socket servers across all RVM's, as of jRuby 1.7.19
+* Unified Server#run removes need for duplication of #run across all Server implementations.
+* Standardized method of rescuing exceptions unique to each type of Server in unified #run method.
 
 0.5.0 (2014-04-15)
-----
+-----
 * Reel::Server(::SSL) renamed to Reel::Server::HTTP and Reel::Server::HTTPS
 * New Reel::Spy API for observing requests and responses from the server
 * Fixes to chunked encoding handling

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-0.6.0
+0.6.0 (2015-03-24)
 -----
 * Fix stack level too deep when writing to ChunkStream
 * Use HTTP::Resonse::Status::REASONS table ( HTTP::Response::* deprecated in the HTTP gem )
@@ -28,7 +28,7 @@
 * Ensure response bodies are always closed
 * Support for passing a fixnum status to Connection#respond
 
-0.4.0
+0.4.0 (2013-09-14)
 -----
 * Rack adapter moved to the reel-rack project
 * Pipelining support
@@ -43,7 +43,7 @@
 * Remove Reel::App (unmaintained, sorry)
 * Reel::CODENAME added (0.4.0 is "Garbo")
 
-0.3.0
+0.3.0 (2013-02-01)
 -----
 * Reel::App: Sinatra-like DSL for defining Reel apps using Octarine
 * Chunked upload support
@@ -53,12 +53,12 @@
 * Bugfix: Send CRLF after chunks
 * Bugfix: Increase TCP connection backlog to 1024
 
-0.2.0
+0.2.0 (2012-09-03)
 -----
 * Initial WebSockets support via Reel::WebSocket
 * Experimental Rack adapter by Alberto Fernández-Capel
 * Octarine (Sinatra-like DSL) support by Grant Rodgers
 
-0.1.0
+0.1.0 (2012-07-12)
 -----
 * Initial release

--- a/lib/reel.rb
+++ b/lib/reel.rb
@@ -14,7 +14,7 @@ require 'reel/response'
 require 'reel/server'
 require 'reel/server/http'
 require 'reel/server/https'
-require 'reel/server/unix'
+require 'reel/server/unix' if !defined? JRUBY_VERSION
 
 require 'reel/websocket'
 require 'reel/stream'

--- a/lib/reel/server.rb
+++ b/lib/reel/server.rb
@@ -9,7 +9,7 @@ module Reel
 
   # Reel::Server::HTTP
   # Reel::Server::HTTPS
-  # Coming soon: Reel::Server::UNIX
+  # Reel::Server::UNIX ( not on jRuby yet )
 
   class Server
     include Celluloid::IO
@@ -48,7 +48,6 @@ module Reel
         begin
           socket = @server.accept
         rescue *@options[:rescue] => ex
-          puts "#{ex.class} // #{ex.message}"
           Logger.warn "Error accepting socket: #{ex.class}: #{ex.to_s}"
           next
         end

--- a/lib/reel/server.rb
+++ b/lib/reel/server.rb
@@ -25,6 +25,15 @@ module Reel
       @callback = callback
       @server   = server
 
+      @options[:rescue] ||= []
+      @options[:rescue] += [
+        Errno::ECONNRESET,
+        Errno::EPIPE,
+        Errno::EINPROGRESS,
+        Errno::ETIMEDOUT,
+        Errno::EHOSTUNREACH
+      ]
+
       @server.listen(options.fetch(:backlog, DEFAULT_BACKLOG))
 
       async.run
@@ -35,7 +44,16 @@ module Reel
     end
 
     def run
-      loop { async.handle_connection @server.accept }
+      loop {
+        begin
+          socket = @server.accept
+        rescue *@options[:rescue] => ex
+          puts "#{ex.class} // #{ex.message}"
+          Logger.warn "Error accepting socket: #{ex.class}: #{ex.to_s}"
+          next
+        end
+        async.handle_connection socket
+      }
     end
 
     def handle_connection(socket)

--- a/lib/reel/server/https.rb
+++ b/lib/reel/server/https.rb
@@ -42,22 +42,9 @@ module Reel
         server = Celluloid::IO::SSLServer.new(@tcpserver, ssl_context)
         options.merge!(host: host, port: port)
 
+        options[:rescue] = [ OpenSSL::SSL::SSLError ]
+        
         super(server, options, &callback)
-      end
-
-      def run
-        loop do
-          begin
-            socket = @server.accept
-          rescue OpenSSL::SSL::SSLError, EOFError,
-                Errno::ECONNRESET, Errno::EPIPE, Errno::EINPROGRESS,
-                Errno::ETIMEDOUT, Errno::EHOSTUNREACH => ex
-            Logger.warn "Error accepting SSLSocket: #{ex.class}: #{ex.to_s}"
-            next
-          end
-
-          async.handle_connection socket
-        end
       end
     end
   end

--- a/spec/reel/http_server_spec.rb
+++ b/spec/reel/http_server_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe Reel::Server::HTTP do
         expect(request.method).to eq 'GET'
         expect(request.version).to eq "1.1"
         expect(request.url).to eq example_path
-
         connection.respond :ok, response_body
-      rescue => ex
       end
     end
 
@@ -36,7 +34,6 @@ RSpec.describe Reel::Server::HTTP do
         request = connection.request
         expect(request.method).to eq 'POST'
         connection.respond :ok, request.body.to_s
-      rescue => ex
       end
     end
 

--- a/spec/reel/https_server_spec.rb
+++ b/spec/reel/https_server_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe Reel::Server::HTTPS do
         expect(request.method).to eq 'GET'
         expect(request.version).to eq "1.1"
         expect(request.url).to eq example_path
-
         connection.respond :ok, response_body
-      rescue => ex
       end
     end
 
@@ -35,10 +33,8 @@ RSpec.describe Reel::Server::HTTPS do
       http         = Net::HTTP.new(endpoint.host, endpoint.port)
       http.use_ssl = true
       http.ca_file = self.ca_file
-
       request = Net::HTTP::Get.new(endpoint.path)
       response = http.request(request)
-
       expect(response.body).to eq response_body
     end
 
@@ -54,9 +50,7 @@ RSpec.describe Reel::Server::HTTPS do
         expect(request.method).to eq 'GET'
         expect(request.version).to eq '1.1'
         expect(request.url).to eq example_path
-
         connection.respond :ok, response_body
-      rescue => ex
       end
     end
 
@@ -66,10 +60,8 @@ RSpec.describe Reel::Server::HTTPS do
       http.ca_file = self.ca_file
       http.cert    = OpenSSL::X509::Certificate.new self.client_cert
       http.key     = OpenSSL::PKey::RSA.new         self.client_key
-
       request  = Net::HTTP::Get.new(endpoint.path)
       response = http.request(request)
-
       expect(response.body).to eq response_body
     end
 
@@ -85,9 +77,7 @@ RSpec.describe Reel::Server::HTTPS do
         expect(request.method).to eq 'GET'
         expect(request.version).to eq '1.1'
         expect(request.url).to eq example_path
-
         connection.respond :ok, response_body
-      rescue => ex
       end
     end
 
@@ -97,9 +87,7 @@ RSpec.describe Reel::Server::HTTPS do
       http.ca_file = self.ca_file
       http.cert    = OpenSSL::X509::Certificate.new self.client_cert_unsigned
       http.key     = OpenSSL::PKey::RSA.new         self.client_key
-
       request  = Net::HTTP::Get.new(endpoint.path)
-
       expect { http.request(request) }.to raise_error(OpenSSL::SSL::SSLError)
     end
 

--- a/spec/reel/unix_server_spec.rb
+++ b/spec/reel/unix_server_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 require 'net/http'
 
+return unless !defined? JRUBY_VERSION or JRUBY_VERSION >= '1.7.19'
+
 RSpec.describe Reel::Server::UNIX do
   let(:endpoint) { URI(example_url) }
   let(:response_body) { "ohai thar" }
@@ -11,9 +13,8 @@ RSpec.describe Reel::Server::UNIX do
     handler = proc do |connection|
       begin
         request = connection.request
-        request.method.should eq 'GET'
+        expect( request.method ).to eq 'GET'
         connection.respond :ok, self.response_body
-      rescue => ex
       end
     end
 
@@ -24,7 +25,6 @@ RSpec.describe Reel::Server::UNIX do
         request = Net::HTTP::Get.new('/')
 
         request.exec(sock, '1.1', path)
-
         response = Net::HTTPResponse.read_new(sock)
         response.reading_body(sock, request.response_body_permitted?) { }
 

--- a/spec/reel/unix_server_spec.rb
+++ b/spec/reel/unix_server_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'net/http'
 
-describe Reel::Server::UNIX do
+RSpec.describe Reel::Server::UNIX do
   let(:endpoint) { URI(example_url) }
   let(:response_body) { "ohai thar" }
 

--- a/spec/reel/unix_server_spec.rb
+++ b/spec/reel/unix_server_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'net/http'
 
-return unless !defined? JRUBY_VERSION or JRUBY_VERSION >= '1.7.19'
+return unless !defined? JRUBY_VERSION
 
 RSpec.describe Reel::Server::UNIX do
   let(:endpoint) { URI(example_url) }


### PR DESCRIPTION
Closes #123 

Including UNIX Server support so we can just flip a switch in the future and turn UNIX Sockets on for jRuby, rather than having to do some nasty merge in the future with `unix_server` growing hair in weird places and starting to smell funny. Everything passes fine under Rubinius. It's good code. Just can't use it under jRuby yet.