### PR TITLE
Do not allow transitioning out of closed

### DIFF
--- a/lib/reel/request/state_machine.rb
+++ b/lib/reel/request/state_machine.rb
@@ -18,7 +18,9 @@ module Reel
         @hijacked = true
       end
 
-      state :closed do
+      # FSM fails open for valid transitions
+      # Set an empty array to disallow transitioning out of closed
+      state :closed, :to => [] do
         @socket.close unless @hijacked || @socket.closed?
       end
     end


### PR DESCRIPTION
I don't have a good way of replicating this @tarcieri, but I can do it with our internal code, so if you want to drop by and poke at it more let me know.

The FSM defaults to failing open, if you don't specify a state it can transition to, it assumes you can transition to anything. Since we shouldn't be able to transition to anything once closed, I set it to empty to stop that.

The issue I was seeing, is it would get stuck into a bad state where the socket that looked like this:

```
--- 127.0.0.1:58815 (AF_INET) disconnected false
HTTP/1.1 200 OK
Connection: close
Content-Length: 14

--- 127.0.0.1:58815 (AF_INET) disconnected false
HTTP/1.1 200 OK
Connection: close
Content-Length: 14

--- 127.0.0.1:58815 (AF_INET) disconnected false
HTTP/1.1 200 OK
Connection: close
Content-Length: 14

--- 127.0.0.1:58815 (AF_INET) disconnected false
HTTP/1.1 200 OK
Connection: close
Content-Length: 14

--- 127.0.0.1:58815 (AF_INET) disconnected false
HTTP/1.1 200 OK
Connection: close
Content-Length: 14

--- 127.0.0.1:58815 (AF_INET) disconnected false
HTTP/1.1 200 OK
Connection: close
Content-Length: 14

--- 127.0.0.1:58815 (AF_INET) disconnected false
HTTP/1.1 200 OK
Connection: close
Content-Length: 14

--- 127.0.0.1:58815 (AF_INET) disconnected false
```

After it made one connection on port 58815. The "false" is my check for `@socket.closed?`. When I checked on the requester side, I only have one request being received (the original one before it looped). This changes it so the actor crashes, which isn't great, but better than being stuck in a loop where it keeps trying to respond.

