### PR TITLE
remove rack dep, add fwd to ping

### DIFF
--- a/lib/reel/websocket.rb
+++ b/lib/reel/websocket.rb
@@ -99,7 +99,10 @@ module Reel
       def_delegators :socket, :write
 
       RACK_HEADERS = {
+        'Origin'                   => 'HTTP_ORIGIN',
         'Sec-WebSocket-Key'        => 'HTTP_SEC_WEBSOCKET_KEY',
+        'Sec-WebSocket-Key1'       => 'HTTP_SEC_WEBSOCKET_KEY1',
+        'Sec-WebSocket-Key2'       => 'HTTP_SEC_WEBSOCKET_KEY2',
         'Sec-WebSocket-Extensions' => 'HTTP_SEC_WEBSOCKET_EXTENSIONS',
         'Sec-WebSocket-Protocol'   => 'HTTP_SEC_WEBSOCKET_PROTOCOL',
         'Sec-WebSocket-Version'    => 'HTTP_SEC_WEBSOCKET_VERSION'

--- a/lib/reel/websocket.rb
+++ b/lib/reel/websocket.rb
@@ -9,6 +9,7 @@ module Reel
 
     attr_reader :socket
     def_delegators :@socket, :addr, :peeraddr
+    def_delegators :@driver, :ping
 
     def initialize(info, connection)
       driver_env = DriverEnvironment.new(info, connection.socket)

--- a/reel.gemspec
+++ b/reel.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'http',             '>= 0.6.0.pre'
   gem.add_runtime_dependency 'http_parser.rb',   '>= 0.6.0'
   gem.add_runtime_dependency 'websocket-driver', '>= 0.5.1'
-  gem.add_runtime_dependency 'rack'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '>= 2.11.0'


### PR DESCRIPTION
this should resolve #186 and #187 - in my testing, this limited amount of rack mimicry works, no need for a full gem dependency and `Rack::MockRequest` instantiation.

also, this adds a forward to the driver for `WebSocket#ping`.