### PR TITLE
graft http/2 onto reel ( 0.6.5 )

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'celluloid'
 gem 'celluloid-io'
 gem 'http'
+gem 'http-2'
 
 gem 'jruby-openssl' if defined? JRUBY_VERSION
 gem 'coveralls', require: false

--- a/examples/http_2.rb
+++ b/examples/http_2.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require 'reel'
+require 'pry'
+
+RES = ''.freeze
+
+LOG = Celluloid.logger
+
+LOG.info "Listening on 127.0.0.1:4567..."
+
+Reel::Connection::HTTP2.on :stream do |s|
+
+  LOG.info "http2 headers: #{s[:headers]}"
+  LOG.info "http2 body: #{s[:body]}"
+
+  res = [
+    "hi there.",
+    "how's it going?",
+    "yay!"
+  ]
+
+  s[:stream].headers({
+    ':status' => '200',
+    'content-length' => res.join(nil).bytesize.to_s,
+    'content-type' => 'text/plain',
+  }, end_stream: false)
+
+  s[:stream].data res[0], end_stream: false
+  Celluloid.sleep 3
+  s[:stream].data res[1], end_stream: false
+  Celluloid.sleep 1
+  s[:stream].data res[2]
+
+end
+
+Reel::Server::HTTP.run('127.0.0.1', 4567) do |http_1_connection|
+
+  http_1_connection.each_request do |request|
+    LOG.info request.inspect
+    request.respond :ok, RES
+  end
+
+end

--- a/lib/reel/connection.rb
+++ b/lib/reel/connection.rb
@@ -1,4 +1,5 @@
 require 'reel/request'
+require 'reel/connection/http_2'
 
 module Reel
   # A connection to the HTTP server
@@ -18,7 +19,7 @@ module Reel
     BUFFER_SIZE = 16384
     attr_reader :buffer_size
 
-    def initialize(socket, buffer_size = nil)
+    def initialize(socket, buffer_size = nil, data = nil)
       @attached    = true
       @socket      = socket
       @keepalive   = true
@@ -28,6 +29,8 @@ module Reel
 
       reset_request
       @response_state = :headers
+
+      @parser << data if data
     end
 
     # Is the connection still active?

--- a/lib/reel/connection/http_2.rb
+++ b/lib/reel/connection/http_2.rb
@@ -1,0 +1,74 @@
+require 'http/2'
+
+module Reel
+  class Connection
+
+    # HTTP/2 connection handler
+    #
+    class HTTP2
+      include Celluloid::Logger
+
+      BUFFER_SIZE = 16384
+
+      attr_reader :buffer_size, :parser, :socket
+
+      class << self
+
+        # accessor for event generic http/2 callbacks
+        #
+        # @return [Hash] eventname => handler proc
+        #
+        def on event = nil, &block
+          @on ||= {}
+          return @on if event.nil?
+          raise ArgumentError unless block_given?
+          @on[event] = block
+          @on
+        end
+
+      end
+
+      # fire up a new connection on the socket
+      #
+      def initialize socket
+        @socket = socket
+        @parser = ::HTTP2::Server.new
+
+        @parser.on :frame do |bytes|
+          @socket.write bytes
+        end
+
+        @parser.on :stream do |stream|
+
+          req, buffer = {}, ''
+          stream.on(:headers) {|h| req = Hash[*h.flatten]}
+          stream.on(:data)    {|d| buffer << d}
+
+          stream.on(:half_close) do
+            HTTP2.on[:stream][{ headers: req, body: buffer, stream: stream }]
+          end
+
+        end
+
+      end
+
+      # shovel data from the socket into the parser.
+      #
+      def readpartial
+        while !@socket.closed? && !@socket.eof?
+          begin
+            data = @socket.readpartial(@buffer_size)
+            @parser << data
+          rescue ::HTTP2::Error::HandshakeError => he
+            raise HTTP2ParseError.new data
+          rescue => e
+            error "Exception: #{e}, #{e.message} - closing socket."
+            @socket.close
+          end
+        end
+      end
+
+    end
+  end
+
+end


### PR DESCRIPTION
* initial stab/spike
* attempts http/2 first, rescues to http/1.x
* requires a "callback", see `examples/http_2.rb`