### PR TITLE
Add option to pass in ssl_params for the server's SSLContext so we can set any param on the SSLContext

### DIFF
--- a/lib/reel/server/https.rb
+++ b/lib/reel/server/https.rb
@@ -21,6 +21,8 @@ module Reel
         ssl_context.cert = OpenSSL::X509::Certificate.new options.fetch(:cert)
         ssl_context.key  = OpenSSL::PKey::RSA.new options.fetch(:key)
 
+        ssl_context.set_params(options[:ssl_params]) if options[:ssl_params]
+
         ssl_context.ca_file          = options[:ca_file]
         ssl_context.ca_path          = options[:ca_path]
         ssl_context.extra_chain_cert = options[:extra_chain_cert]

--- a/spec/reel/https_server_spec.rb
+++ b/spec/reel/https_server_spec.rb
@@ -105,6 +105,39 @@ RSpec.describe Reel::Server::HTTPS do
     raise ex if ex
   end
 
+  it "allows setting the ssl_version used by the server" do
+    ex = nil
+
+    handler = proc do |connection|
+      begin
+        request = connection.request
+        expect(request.method).to eq 'GET'
+        expect(request.version).to eq "1.1"
+        expect(request.url).to eq example_path
+
+        connection.respond :ok, response_body
+      rescue => ex
+      end
+    end
+
+    with_reel_https_server(handler, :ssl_params => {:ssl_version => :TLSv1}) do
+      http             = Net::HTTP.new(endpoint.host, endpoint.port)
+      http.use_ssl     = true
+      http.ca_file     = self.ca_file
+      http.ssl_version = :TLSv1_1
+
+      request = Net::HTTP::Get.new(endpoint.path)
+
+      expect { http.request(request) }.to raise_error(OpenSSL::SSL::SSLError, /wrong version number/)
+
+      http.ssl_version = :TLSv1
+      response = http.request(request)
+      expect(response.body).to eq response_body
+    end
+
+    raise ex if ex
+  end
+
   def with_reel_https_server(handler, options = {})
     options = {
       :cert => server_cert,


### PR DESCRIPTION
This PR will allow a user to set the ssl_version, ciphers or options used by the server