### PR TITLE
Add option to pass in ssl_params for the server's SSLContext so we can set any param on the SSLContext

### DIFF
--- a/lib/reel/server/https.rb
+++ b/lib/reel/server/https.rb
@@ -21,6 +21,8 @@ module Reel
         ssl_context.cert = OpenSSL::X509::Certificate.new options.fetch(:cert)
         ssl_context.key  = OpenSSL::PKey::RSA.new options.fetch(:key)
 
+        ssl_context.set_params(options[:ssl_params]) if options[:ssl_params]
+
         ssl_context.ca_file          = options[:ca_file]
         ssl_context.ca_path          = options[:ca_path]
         ssl_context.extra_chain_cert = options[:extra_chain_cert]


### PR DESCRIPTION
This PR will allow a user to set the ssl_version, ciphers or options used by the server

[The original PR](https://github.com/celluloid/reel/pull/205) was against master, closed that one in favor of this one.