### PR TITLE
fix https_server test in JRuby that has a different message for the S…

### DIFF
--- a/spec/reel/https_server_spec.rb
+++ b/spec/reel/https_server_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Reel::Server::HTTPS do
 
       request = Net::HTTP::Get.new(endpoint.path)
 
-      expect { http.request(request) }.to raise_error(OpenSSL::SSL::SSLError, /wrong version number/)
+      expect { http.request(request) }.to raise_error(OpenSSL::SSL::SSLError)
 
       http.ssl_version = :TLSv1
       response = http.request(request)


### PR DESCRIPTION
This should fix https://github.com/celluloid/reel/issues/207.  The problem is JRuby returns a different error message than MRI for this case.

JRuby message: "Server chose TLSv1, but that protocol version is not enabled or not supported by the client."

MRI message: "SSL_connect returned=1 errno=0 state=SSLv3 read server hello A: wrong version number"