### PR TITLE
Drop 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,14 @@
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.2
-  - ruby-head
-  - jruby
-  - jruby-head
-  - rbx-2
+language: ruby
+sudo: false
 
+rvm:
+  - 2.0.0
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
+  - jruby-9.0.5.0
 matrix:
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
-    - rvm: rbx-2
+  fast_finish: true
 
 notifications:
   irc: "irc.freenode.org#celluloid"


### PR DESCRIPTION
1.9 is dead:

https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended/

Let's drop support for it in Reel.