### PR TITLE
Skip failing specs

### DIFF
--- a/spec/reel/websocket_spec.rb
+++ b/spec/reel/websocket_spec.rb
@@ -60,7 +60,9 @@ RSpec.describe Reel::WebSocket do
   end
 
   describe "WebSocket#next_message" do
-    it "triggers on the next sent message", pending: "update to new Celluloid internal APIs" do
+    it "triggers on the next sent message" do
+      skip "update to new Celluloid internal APIs"
+
       with_websocket_pair do |client, websocket|
         f = Celluloid::Future.new
         websocket.on_message do |message|
@@ -79,7 +81,9 @@ RSpec.describe Reel::WebSocket do
   end
 
   describe "WebSocket#read_every" do
-    it "automatically executes read", pending: "update to new Celluloid internal APIs" do
+    it "automatically executes read" do
+      skip "update to new Celluloid internal APIs"
+
       with_websocket_pair do |client, websocket|
         class MyActor
           include Celluloid


### PR DESCRIPTION
Even using pending means they're still run, and they hang on JRuby

Skip them instead