### PR TITLE
remove rack dep, add ws ping forward

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 0.6.0 (2016-02-13)
+## 0.6.0 "Garland" (2016-02-13)
 
 * [#148](https://github.com/celluloid/reel/pull/148):
   Fix stack level too deep when writing to ChunkStream.
@@ -41,7 +41,7 @@
   Fix ChunkStream termination.
   (**@ogoid**)
 
-## 0.5.0 (2014-04-15)
+## 0.5.0 "Bette" (2014-04-15)
 
 * Reel::Server(::SSL) renamed to Reel::Server::HTTP and Reel::Server::HTTPS
 * New Reel::Spy API for observing requests and responses from the server
@@ -51,7 +51,7 @@
 * Ensure response bodies are always closed
 * Support for passing a fixnum status to Connection#respond
 
-## 0.4.0
+## 0.4.0 "Garbo"
 
 * Rack adapter moved to the reel-rack project
 * Pipelining support

--- a/lib/reel/websocket.rb
+++ b/lib/reel/websocket.rb
@@ -94,24 +94,24 @@ module Reel
     class DriverEnvironment
       extend Forwardable
 
-      attr_reader :env, :url, :socket
+      attr_reader :env, :socket
 
-      def_delegators :socket, :write
+      def_delegator :@info, :url
+      def_delegator :@socket, :write
 
       RACK_HEADERS = {
-        'Origin'                   => 'HTTP_ORIGIN',
-        'Sec-WebSocket-Key'        => 'HTTP_SEC_WEBSOCKET_KEY',
-        'Sec-WebSocket-Key1'       => 'HTTP_SEC_WEBSOCKET_KEY1',
-        'Sec-WebSocket-Key2'       => 'HTTP_SEC_WEBSOCKET_KEY2',
-        'Sec-WebSocket-Extensions' => 'HTTP_SEC_WEBSOCKET_EXTENSIONS',
-        'Sec-WebSocket-Protocol'   => 'HTTP_SEC_WEBSOCKET_PROTOCOL',
-        'Sec-WebSocket-Version'    => 'HTTP_SEC_WEBSOCKET_VERSION'
-      }
+        'HTTP_ORIGIN'                   => 'Origin',
+        'HTTP_SEC_WEBSOCKET_KEY'        => 'Sec-WebSocket-Key',
+        'HTTP_SEC_WEBSOCKET_KEY1'       => 'Sec-WebSocket-Key1',
+        'HTTP_SEC_WEBSOCKET_KEY2'       => 'Sec-WebSocket-Key2',
+        'HTTP_SEC_WEBSOCKET_EXTENSIONS' => 'Sec-WebSocket-Extensions',
+        'HTTP_SEC_WEBSOCKET_PROTOCOL'   => 'Sec-WebSocket-Protocol',
+        'HTTP_SEC_WEBSOCKET_VERSION'    => 'Sec-WebSocket-Version'
+      }.freeze
 
       def initialize(info, socket)
-        @env, @url = {}, info.url
-        RACK_HEADERS.each {|k,v| @env[v] = info.headers[k]}
-        @socket = socket
+        @info, @socket = info, socket
+        @env = Hash.new {|h,k| @info.headers[RACK_HEADERS[k]]}
       end
     end
 

--- a/lib/reel/websocket.rb
+++ b/lib/reel/websocket.rb
@@ -99,7 +99,10 @@ module Reel
       def_delegators :socket, :write
 
       RACK_HEADERS = {
+        'Origin'                   => 'HTTP_ORIGIN',
         'Sec-WebSocket-Key'        => 'HTTP_SEC_WEBSOCKET_KEY',
+        'Sec-WebSocket-Key1'       => 'HTTP_SEC_WEBSOCKET_KEY1',
+        'Sec-WebSocket-Key2'       => 'HTTP_SEC_WEBSOCKET_KEY2',
         'Sec-WebSocket-Extensions' => 'HTTP_SEC_WEBSOCKET_EXTENSIONS',
         'Sec-WebSocket-Protocol'   => 'HTTP_SEC_WEBSOCKET_PROTOCOL',
         'Sec-WebSocket-Version'    => 'HTTP_SEC_WEBSOCKET_VERSION'

--- a/reel.gemspec
+++ b/reel.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'http',             '>= 0.6.0.pre'
   gem.add_runtime_dependency 'http_parser.rb',   '>= 0.6.0'
   gem.add_runtime_dependency 'websocket-driver', '>= 0.5.1'
-  gem.add_runtime_dependency 'rack'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '>= 2.11.0'


### PR DESCRIPTION
see #189 #191

* removes rack dependency, emulates websocket-driver needed `env` keys/vals
* adds `Reel::WebSocket#ping` forward to `@driver`