### PR TITLE
update readme for websocket gem changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 > "A dizzying lifetime... reeling by on celluloid" _-- Rush / Between The Wheels_
 
 Reel is a fast, non-blocking "evented" web server
-built on [http_parser.rb][parser], [websocket_parser][websockets],
+built on [http_parser.rb][parser], [websocket-driver][websockets],
 [Celluloid::IO][celluloidio], and [nio4r][nio4r]. Thanks to Celluloid,
 Reel also works great for multithreaded applications
 and provides traditional multithreaded blocking I/O support too.
 
 [parser]: https://github.com/tmm1/http_parser.rb
-[websockets]: https://github.com/afcapel/websocket_parser
+[websockets]: https://github.com/faye/websocket-driver-ruby
 [celluloidio]: https://github.com/celluloid/celluloid-io
 [nio4r]: https://github.com/celluloid/nio4r
 


### PR DESCRIPTION
websocket_parser is only used in testing now, AFAIK.