### PR TITLE
Added tests for Reel::Request

### DIFF
--- a/spec/reel/connection_spec.rb
+++ b/spec/reel/connection_spec.rb
@@ -338,6 +338,29 @@ RSpec.describe Reel::Connection do
     end
   end
 
+  it "returns friendlier inspect output" do
+    with_socket_pair do |client, peer|
+      connection = Reel::Connection.new(peer)
+      client << ExampleRequest.new.to_s
+      request = connection.request
+
+      expect(request.inspect).to eq '#<Reel::Request GET / HTTP/1.1 @headers={"Host"=>"www.example.com", "Connection"=>"keep-alive", "User-Agent"=>"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_3) AppleWebKit/535.11 (KHTML, like Gecko) Chrome/17.0.963.78 S", "Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "Accept-Encoding"=>"gzip,deflate,sdch", "Accept-Language"=>"en-US,en;q=0.8", "Accept-Charset"=>"ISO-8859-1,utf-8;q=0.7,*;q=0.3"}>'
+    end
+  end
+
+  it "raises an exception if not in chunked body mode" do
+    with_socket_pair do |client, peer|
+      connection = Reel::Connection.new(peer)
+      client << ExampleRequest.new.tap{ |r|
+        r['Connection'] = 'keep-alive'
+      }.to_s
+      request = connection.request
+      request.respond :ok, :transfer_encoding => ''
+
+      expect {request << "Hello"}.to raise_error(Reel::StateError)
+    end
+  end
+
   context "#readpartial" do
     it "streams request bodies" do
       with_socket_pair do |client, peer|


### PR DESCRIPTION
Added two new tests for Reel::Request class. Please check the correct context of the test comment if better position for the tests can be provided.

Code base coverage increased from **91.35%** to **91.57%** covered.
Coverage for `lib/reel/request.rb` increased from **97.01%** to **100%**