### PR TITLE
add server access from requests

### DIFF
--- a/lib/reel/connection.rb
+++ b/lib/reel/connection.rb
@@ -16,13 +16,14 @@ module Reel
 
     # Attempt to read this much data
     BUFFER_SIZE = 16384
-    attr_reader :buffer_size
+    attr_reader :buffer_size, :server
 
-    def initialize(socket, buffer_size = nil)
+    def initialize(socket, buffer_size = nil, server = nil)
       @attached    = true
       @socket      = socket
       @keepalive   = true
       @buffer_size = buffer_size || BUFFER_SIZE
+      @server      = server
       @parser      = Request::Parser.new(self)
       @request_fsm = Request::StateMachine.new(@socket)
 

--- a/lib/reel/request.rb
+++ b/lib/reel/request.rb
@@ -14,7 +14,7 @@ module Reel
 
     def_delegators :@connection, :remote_addr, :respond
     def_delegator  :@response_writer, :handle_response
-    attr_reader :body
+    attr_reader :body, :connection
 
     # request_info is a RequestInfo object including the headers and
     # the url, method and http version.

--- a/lib/reel/server.rb
+++ b/lib/reel/server.rb
@@ -44,7 +44,7 @@ module Reel
         socket = Reel::Spy.new(socket, @spy)
       end
 
-      connection = Connection.new(socket)
+      connection = Connection.new(socket, nil, self)
 
       begin
         @callback.call(connection)

--- a/spec/reel/connection_spec.rb
+++ b/spec/reel/connection_spec.rb
@@ -338,6 +338,19 @@ RSpec.describe Reel::Connection do
     end
   end
 
+  it "allows access to server instance" do
+    with_socket_pair do |client, peer|
+      server = Object.new
+      connection = Reel::Connection.new(peer, nil, server)
+      example_request = ExampleRequest.new
+
+      client << example_request.to_s
+      request = connection.request
+
+      expect(request.connection.server).to eq server
+    end
+  end
+
   context "#readpartial" do
     it "streams request bodies" do
       with_socket_pair do |client, peer|


### PR DESCRIPTION
* add `server = nil` param to +Connection+ initializer
* add `self` to +Connection+ construction in +Server+
* add `@server` reader on +Connection+
* add `@connection` reader on +Request+
* add test for above

this gives a developer easy access to the server reactor instance from each request.

```ruby
Reel::Server::HTTP.new('127.0.0.1',4567) do |c|
  c.each_request do |r|
    r.connection.server.after(3){ puts 'hi 3 seconds later' }
    r.respond :ok, ''
  end
end
```