### PR TITLE
Update create_certs.rb

### DIFF
--- a/spec/support/create_certs.rb
+++ b/spec/support/create_certs.rb
@@ -48,7 +48,7 @@ client_cert.subject.common_name  = '127.0.0.1'
 client_cert.serial_number.number = 1
 client_cert.key_material.generate_key
 client_cert.parent = ca
-client_cert.sign!
+client_cert.sign! 'extensions' => { 'keyUsage' => { 'usage' => %w(digitalSignature) } }
 
 client_cert_path = File.join(certs_dir, 'client.crt')
 client_key_path  = File.join(certs_dir, 'client.key')


### PR DESCRIPTION
The newer ruby-certificate-authority will cause the Reel::Server::HTTPS test to fail with the following:

```
Reel::Server::HTTPS verifies client SSL certs when provided with a CA
     Failure/Error: response = http.request(request)

     OpenSSL::SSL::SSLError:
       SSL_connect returned=1 errno=0 state=unknown state: sslv3 alert unsupported certificate
     # /usr/lib/ruby/2.3.0/net/http.rb:933:in `connect_nonblock'
     # /usr/lib/ruby/2.3.0/net/http.rb:933:in `connect'
     # /usr/lib/ruby/2.3.0/net/http.rb:863:in `do_start'
     # /usr/lib/ruby/2.3.0/net/http.rb:852:in `start'
     # /usr/lib/ruby/2.3.0/net/http.rb:1398:in `request'
     # ./spec/reel/https_server_spec.rb:70:in `block (3 levels) in <top (required)>'
     # ./spec/reel/https_server_spec.rb:115:in `with_reel_https_server'
     # ./spec/reel/https_server_spec.rb:62:in `block (2 levels) in <top (required)>'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example.rb:254:in `instance_exec'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example.rb:254:in `block in run'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /usr/lib/ruby/vendor_ruby/rspec/core/hooks.rb:464:in `block in run'
     # /usr/lib/ruby/vendor_ruby/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /usr/lib/ruby/vendor_ruby/rspec/core/hooks.rb:464:in `run'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example.rb:251:in `run'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example_group.rb:627:in `block in run_examples'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example_group.rb:623:in `map'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example_group.rb:623:in `run_examples'
     # /usr/lib/ruby/vendor_ruby/rspec/core/example_group.rb:589:in `run'
     # /usr/lib/ruby/vendor_ruby/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /usr/lib/ruby/vendor_ruby/rspec/core/runner.rb:113:in `map'
     # /usr/lib/ruby/vendor_ruby/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /usr/lib/ruby/vendor_ruby/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /usr/lib/ruby/vendor_ruby/rspec/core/runner.rb:112:in `block in run_specs'
     # /usr/lib/ruby/vendor_ruby/rspec/core/reporter.rb:77:in `report'
     # /usr/lib/ruby/vendor_ruby/rspec/core/runner.rb:111:in `run_specs'
     # /usr/lib/ruby/vendor_ruby/rspec/core/runner.rb:87:in `run'
     # /usr/lib/ruby/vendor_ruby/rspec/core/runner.rb:71:in `run'
     # /usr/lib/ruby/vendor_ruby/rspec/core/runner.rb:45:in `invoke'
     # /usr/bin/rspec:4:in `<main>'
```

The unsupported certificate error is because the client cert that is created was not created with the correct x509v3 extension that is needed for client authentication, and when the cert is checked, this fails