### PR TITLE
Fix missing IOError rescue on shutdown (#212)

### DIFF
--- a/lib/reel/server.rb
+++ b/lib/reel/server.rb
@@ -36,6 +36,7 @@ module Reel
 
     def run
       loop { async.handle_connection @server.accept }
+    rescue IOError
     end
 
     def handle_connection(socket)


### PR DESCRIPTION
I'm not entirely sure that this rescue is in the right place but it does fix the issue. I did try putting it in `handle_connection` first but that was ineffective.