### PR TITLE
Travis: jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 - jruby-1.7.27
 - 2.1.10
 - 2.2.7
-- jruby-9.1.12.0
+- jruby-9.1.13.0
 - 2.3.4
 - 2.4.1
 - ruby-head
@@ -12,7 +12,7 @@ rvm:
 matrix:
   fast_finish: true
   allow_failures:
-  - rvm: jruby-9.1.12.0
+  - rvm: jruby-9.1.13.0
   - rvm: 2.1.10
   - rvm: 2.3.4
   - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html