### PR TITLE
Ruby 2.4 support: avoid Fixnum mention

### DIFF
--- a/lib/reel/connection.rb
+++ b/lib/reel/connection.rb
@@ -98,7 +98,7 @@ module Reel
       end
 
       case response
-      when Symbol, Fixnum, Integer
+      when Symbol, Integer
         response = Response.new(response, headers, body)
       when Response
       else raise TypeError, "invalid response: #{response.inspect}"


### PR DESCRIPTION
  - see #247 

This change is a response to that Issue reported.

I was thinking: Do I need to also not match the `case` when `response` is a Bignum?